### PR TITLE
Update message_entity.rs

### DIFF
--- a/src/model/message_entity.rs
+++ b/src/model/message_entity.rs
@@ -38,7 +38,7 @@ pub enum MessageEntity {
     #[serde(rename = "underline")]
     Underline(TextBlock),
     /// strikethrough text
-    #[serde(rename = "strike_through")]
+    #[serde(rename = "strikethrough")]
     StrikeThrough(TextBlock),
     /// A monowidth code string
     #[serde(rename = "code")]


### PR DESCRIPTION
According to the documentation (https://core.telegram.org/bots/api#messageentity) the message entity is `strikethrough` and not `strike_through`