### PR TITLE
fix: deserialize error for get_chat api function

### DIFF
--- a/src/api/api.rs
+++ b/src/api/api.rs
@@ -1,6 +1,6 @@
 use super::{response::Response, types::*, APIEndpoint};
 use crate::{
-    model::*,
+    model::{*, raw::RawChat},
     utils::{
         result::{Result, TelegramError},
         FormDataFile,
@@ -966,9 +966,14 @@ pub trait API: Sync {
     /// of a user, group or channel, etc.). Returns a [`Chat`] object on
     /// success.
     async fn get_chat(&self, data: GetChat) -> Result<Chat> {
-        self.get(APIEndpoint::GetChat, Some(serde_json::to_value(data)?))
-            .await?
-            .into()
+        Ok(
+            Into::<Chat>::into(
+                Into::<Result<RawChat>>::into(
+                    self.get(APIEndpoint::GetChat, Some(serde_json::to_value(data)?))
+                    .await?
+                )?
+            )
+        )
     }
 
     /// Use this method to get a list of administrators in a chat.


### PR DESCRIPTION
Fix for https://github.com/CalliEve/telexide/issues/31:

The problem was that you're trying to deserialize the `Chat` struct directly, but you have a `RawChat` struct for deserialization that you can convert into a `Chat` object. I added these Into statements into the `get_chat` function of the api.