### PR TITLE
fix: message entity hashtag and cashtag name

### DIFF
--- a/src/model/message_entity.rs
+++ b/src/model/message_entity.rs
@@ -11,10 +11,10 @@ pub enum MessageEntity {
     #[serde(rename = "mention")]
     Mention(TextBlock),
     /// A hashtag (`#hashtag`)
-    #[serde(rename = "hash_tag")]
+    #[serde(rename = "hashtag")]
     HashTag(TextBlock),
     /// A cashtag (`$USD`)
-    #[serde(rename = "cash_tag")]
+    #[serde(rename = "cashtag")]
     CashTag(TextBlock),
     /// A bot command (`/start@bot_name`)
     #[serde(rename = "bot_command")]


### PR DESCRIPTION
As you can see on [https://core.telegram.org/api/entities](https://core.telegram.org/api/entities) the name of the hashtag and cashtag entity types are `hashtag` and `cashtag` but you use these names with an underscore.