### PR TITLE
fix: duplicate example package repeat_image_bot

### DIFF
--- a/examples/upload_image/Cargo.toml
+++ b/examples/upload_image/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "repeat_image_bot"
+name = "upload_image_bot"
 version = "0.1.0"
 authors = ["my name <my@email.address>"]
 edition = "2021"


### PR DESCRIPTION
If you try to compile a package depending on telexide you'll get this warning: 
```
warning: skipping duplicate package `repeat_image_bot` found at `.../telexide-8166ea2103f01644/afdfdb0/examples/upload_image`
```
Fixing the name pf the upload image example package fixes this issue.